### PR TITLE
Improve client-side language handling

### DIFF
--- a/static/js/eve-ui-config.js
+++ b/static/js/eve-ui-config.js
@@ -6,7 +6,7 @@ var eveui_imageserver = function(image_ref) {
 	return eve_image(encodeURI(image_ref), 'png');
 };
 // fix for getting names for modules from ccp api that are in the users browser language
-eveui_accept_language = document.getElementById('lang-code').getAttribute('content');
+eveui_accept_language = document.getElementById('htmltag').getAttribute('lang');
 if (eveui_accept_language.startsWith('en_') || eveui_accept_language == 'en') {
 	eveui_accept_language = 'en_us';
 }

--- a/static/js/eve-ui-config.js
+++ b/static/js/eve-ui-config.js
@@ -6,7 +6,7 @@ var eveui_imageserver = function(image_ref) {
 	return eve_image(encodeURI(image_ref), 'png');
 };
 // fix for getting names for modules from ccp api that are in the users browser language
-eveui_accept_language = document.getElementById('htmltag').getAttribute('lang');
+eveui_accept_language = document.documentElement.getAttribute('lang');
 if (eveui_accept_language.startsWith('en_') || eveui_accept_language == 'en') {
 	eveui_accept_language = 'en_us';
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html lang="">
+<html id="htmltag" lang="{{ lang_code }}">
 <head>
 <meta charset="utf-8">
-<meta id="lang-code" name="lang" content="{{ lang_code }}">
 <meta name="csrf-token" content="{{csrf_token()}}">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="eve-image-server" content="{{eve_proxy_js}}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="htmltag" lang="{{ lang_code }}">
+<html lang="{{ lang_code }}">
 <head>
 <meta charset="utf-8">
 <meta name="csrf-token" content="{{csrf_token()}}">

--- a/templates/partials/i18n.js
+++ b/templates/partials/i18n.js
@@ -1,6 +1,5 @@
 var i18nloaded = $.i18n({
 	locale: '{{ lang_code }}'
 }).load({
-	en: {% assets "i18n.en" %}'{{ ASSET_URL }}'{% endassets %},
-	de: {% assets "i18n.de" %}'{{ ASSET_URL }}'{% endassets %},
+	"{{ lang_code }}": {% assets "i18n." + lang_code %}"{{ ASSET_URL }}"{% endassets %}
 });


### PR DESCRIPTION
Store language locale in the html lang attribute to help client-side translation and only load required locale files.