### PR TITLE
Move xup form js to a static file

### DIFF
--- a/static/js/xup-form.js
+++ b/static/js/xup-form.js
@@ -4,6 +4,7 @@ $(document).ready(function() {
 	var calbsgrp = document.getElementById('grp-cbslvl');
 	var logilvlgrp = document.getElementById('grp-logilvl');
 	var logi_select = document.getElementById('logi');
+	var cbs_select = document.getElementById('cbs');
 	var resist_regex = /\[Rattlesnake|fitting:17918|\[Scorpion Navy Issue|fitting:3230|\[Rokh|fitting:24688/;
 	var logi_regex = /fitting:11985|\[Basilisk|fitting:11978|\[Scimitar/;
 	var checkExtra = function(e) {
@@ -11,10 +12,10 @@ $(document).ready(function() {
 		var currentText = textarea.val();
 		if (resist_regex.test(currentText)) {
 			$(calbsgrp).show();
-			logi_select.required=true;
+			cbs_select.required=true;
 		} else {
 			$(calbsgrp).hide();
-			logi_select.required=false;
+			cbs_select.required=false;
 		}
 		if (logi_regex.test(currentText)) {
 			$(logilvlgrp).show();

--- a/static/js/xup-form.js
+++ b/static/js/xup-form.js
@@ -1,4 +1,5 @@
-<script>
+'use strict';
+
 $(document).ready(function() {
 	var calbsgrp = document.getElementById('grp-cbslvl');
 	var logilvlgrp = document.getElementById('grp-logilvl');
@@ -29,5 +30,3 @@ $(document).ready(function() {
 	fakeEv.target.addEventListener('input', checkExtra, false);
 	checkExtra(fakeEv);
 });
-
-</script>

--- a/static/js/xup-form.js
+++ b/static/js/xup-form.js
@@ -4,7 +4,6 @@ $(document).ready(function() {
 	var calbsgrp = document.getElementById('grp-cbslvl');
 	var logilvlgrp = document.getElementById('grp-logilvl');
 	var logi_select = document.getElementById('logi');
-	var cbs_select = document.getElementById('cbs');
 	var resist_regex = /\[Rattlesnake|fitting:17918|\[Scorpion Navy Issue|fitting:3230|\[Rokh|fitting:24688/;
 	var logi_regex = /fitting:11985|\[Basilisk|fitting:11978|\[Scimitar/;
 	var checkExtra = function(e) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,7 +59,9 @@
 		{% endif %}
 
 		{% if group and (not is_on_wl) and (not (perm_manager.get_permission('fleet_management').can() or perm_manager.get_permission('fits_view').can())) and group.enabled %}
-			{% include "xup-form.js" %}
+			{% assets filters="babili",	output="gen/xup-form.%(version)s.js", "js/xup-form.js" %}
+				<script type="text/javascript" src="{{ ASSET_URL }}"></script>
+			{% endassets %}
 		{% endif %}
 
 		{% if is_on_wl %}

--- a/templates/xup.html
+++ b/templates/xup.html
@@ -5,7 +5,9 @@
 {% block head %}
 {{ super() }}
 {% if groups|length > 0 %}
-{% include "xup-form.js" %}
+{% assets filters="babili",	output="gen/xup-form.%(version)s.js", "js/xup-form.js" %}
+	<script type="text/javascript" src="{{ ASSET_URL }}"></script>
+{% endassets %}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Use xup form as a static file to avoid resending via templates.