### PR TITLE
Disable asset auto building

### DIFF
--- a/waitlist/__init__.py
+++ b/waitlist/__init__.py
@@ -102,11 +102,15 @@ HTMLMIN(app)
 
 # init assets environment
 assets = Environment(app)
+assets.auto_build = (config.debug_enabled or config.auto_build)
 register_filter(BabiliFilter)
 register_filter(JsonMinFilter)
 register_filter(CSSOptimizerFilter)
 register_asset_bundles(assets)
 
+if not assets.auto_build:
+    for bundle in assets:
+        bundle.build()
 
 class MiniJSONEncoder(LazyJSONEncoder):
     """Minify JSON output."""

--- a/waitlist/utility/config.py
+++ b/waitlist/utility/config.py
@@ -39,6 +39,7 @@ config.set_if_not_exists("app", "community_name", "IncWaitlist")
 config.set_if_not_exists("app", "user_agent", "Bruce Warhead: Eve Incursion Waitlist")
 config.set_if_not_exists("app", "domain", "localhost")
 config.set_if_not_exists("app", "using_proxy", "False")
+config.set_if_not_exists("app", "auto_build", "False")
 
 if not config.has_section("crest"):
     config.add_section("crest")
@@ -141,6 +142,7 @@ user_agent = config.get("app", "user_agent")+"/"+version.version
 
 domain = config.get("app", "domain")
 using_proxy = config.get("app", "using_proxy") == "True"
+auto_build =  config.get("app", "auto_build") == "True"
 
 overview_show_count_for_approvals = config.get("overview", "show_count_for_approvals") == "True"
 


### PR DESCRIPTION
Disable asset auto building by default to prevent multiple builds of the same bundles running concurrently, unless debug or auto build specified in config.